### PR TITLE
Fixed "port" map being used under args. Closes #1

### DIFF
--- a/charts/ingress-controller/templates/daemonset.yaml
+++ b/charts/ingress-controller/templates/daemonset.yaml
@@ -31,9 +31,8 @@ spec:
         {{- if .Values.qumine.debug }}
           - --debug
         {{- end }}
-          - ""
-      - name: PORT
-        value: "{{ .Values.qumine.port }}"
+          - name: PORT
+            value: "{{ .Values.qumine.port }}"
         ports:
         - name: ingress
           containerPort: {{ .Values.qumine.port }}

--- a/charts/ingress-controller/templates/daemonset.yaml
+++ b/charts/ingress-controller/templates/daemonset.yaml
@@ -31,8 +31,10 @@ spec:
         {{- if .Values.qumine.debug }}
           - --debug
         {{- end }}
-          - name: PORT
-            value: "{{ .Values.qumine.port }}"
+          - "$(PORT)]"
+        env:
+        - name: PORT
+          value: "{{ .Values.qumine.port }}"
         ports:
         - name: ingress
           containerPort: {{ .Values.qumine.port }}

--- a/charts/ingress-controller/templates/daemonset.yaml
+++ b/charts/ingress-controller/templates/daemonset.yaml
@@ -31,8 +31,8 @@ spec:
         {{- if .Values.qumine.debug }}
           - --debug
         {{- end }}
-        - name: PORT
-          value: "{{ .Values.qumine.port }}"
+      - name: PORT
+        value: "{{ .Values.qumine.port }}"
         ports:
         - name: ingress
           containerPort: {{ .Values.qumine.port }}

--- a/charts/ingress-controller/templates/daemonset.yaml
+++ b/charts/ingress-controller/templates/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
       {{- end }}
       containers:
       - name: ingress-controller
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         {{- if .Values.resources }}
         resources: {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/ingress-controller/templates/daemonset.yaml
+++ b/charts/ingress-controller/templates/daemonset.yaml
@@ -27,10 +27,11 @@ spec:
         {{- if .Values.resources }}
         resources: {{- toYaml .Values.resources | nindent 12 }}
         {{- end }}
-        {{- if .Values.qumine.debug }}
         args:
+        {{- if .Values.qumine.debug }}
           - --debug
         {{- end }}
+          - ""
       - name: PORT
         value: "{{ .Values.qumine.port }}"
         ports:

--- a/charts/ingress-controller/templates/daemonset.yaml
+++ b/charts/ingress-controller/templates/daemonset.yaml
@@ -27,8 +27,8 @@ spec:
         {{- if .Values.resources }}
         resources: {{- toYaml .Values.resources | nindent 12 }}
         {{- end }}
-        args:
         {{- if .Values.qumine.debug }}
+        args:
           - --debug
         {{- end }}
       - name: PORT


### PR DESCRIPTION
In the daemonset.yml file, the port prop under container: "ingress-controller" was used directly as a "map" instead of a env value.