### PR TITLE
set containerport for bluemap to 9090

### DIFF
--- a/charts/minecraft-server/templates/deployment.yaml
+++ b/charts/minecraft-server/templates/deployment.yaml
@@ -134,7 +134,7 @@ spec:
         imagePullPolicy: {{ .Values.integrations.bluemap.image.pullPolicy | quote }}
         ports:
         - name: bluemap
-          containerPort: 8081
+          containerPort: 9090
         resources:
           limits:
             cpu: 500m


### PR DESCRIPTION
Resolves #10 

This sets the containerport for bluemap to 9090.

<a href="https://gitpod.io/#https://github.com/qumine/charts/pull/11"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

